### PR TITLE
Add "adapters" aliases for LayerInterfaces

### DIFF
--- a/cleanarch/cleanarch.go
+++ b/cleanarch/cleanarch.go
@@ -57,6 +57,8 @@ var layersAliases = map[string]Layer{
 	// Interfaces
 	"interfaces": LayerInterfaces,
 	"interface":  LayerInterfaces,
+	"adapters":  LayerInterfaces,
+	"adapter":  LayerInterfaces,
 
 	// Infrastructure
 	"infrastructure": LayerInfrastructure,


### PR DESCRIPTION
Hi,

In the article [The Clean Architecture](https://8thlight.com/blog/uncle-bob/2012/08/13/the-clean-architecture.html) the layer 3 is called "Interface Adapters". Currently `go-cleanarch` only supports using the term `interfaces`. When using Go, we found the term "interface" to be confusing and decided to use "adapters" instead to avoid any confusion. This PR adds support for the term `adapters` for the layer 3.